### PR TITLE
Feat: add holidays controller

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,8 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.8)
+    nokogiri (1.14.0-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.14.0-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.14.0-x86_64-linux)
@@ -161,6 +163,7 @@ GEM
     zeitwerk (2.6.6)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-21
   x86_64-linux
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,76 @@ Obtiene los precios de un combustible específico de Uruguay (Ancap).
 
 - 500 Internal Server Error: Si ocurre algún error en el servidor al obtener los precios de combustibles.
 
+## Holidays
+
+### GET /api/v1/holidays
+
+Obtiene una lista de todas las festividades y días feriados en Uruguay para un año determinado.
+
+**Parámetros**
+
+- year (obligatorio): El año para el cual se desean obtener las festividades. Debe ser un número entero de cuatro dígitos.
+
+**Respuesta**
+
+- 200 OK: Devuelve un objeto JSON que contiene información sobre cada festividad, incluyendo el mes y día en que se celebra, el día de la semana, el nombre de la festividad y el tipo (oficial o no oficial).
+
+- 400 Bad Request: Si se proporciona un año inválido o no se proporciona ningún año.
+
+### GET /api/v1/holidays/official
+
+Obtiene una lista de todas las festividades y días feriados oficiales en Uruguay para un año determinado.
+
+**Parámetros**
+
+- year (obligatorio): El año para el cual se desean obtener las festividades. Debe ser un número entero de cuatro dígitos.
+
+**Respuesta**
+
+- 200 OK: Devuelve un objeto JSON que contiene información sobre cada festividad oficial, incluyendo el mes y día en que se celebra, el día de la semana, el nombre de la festividad y el tipo (oficial).
+
+- 400 Bad Request: Si se proporciona un año inválido o no se proporciona ningún año.
+
+### GET /api/v1/holidays/official_and_non_working
+
+Obtiene una lista de todas las festividades y días feriados oficiales y no laborables en Uruguay para un año determinado.
+
+**Parámetros**
+
+- year (obligatorio): El año para el cual se desean obtener las festividades. Debe ser un número entero de cuatro dígitos.
+
+**Respuesta**
+
+- 200 OK: Devuelve un objeto JSON que contiene información sobre cada festividad oficial y no laborable, incluyendo el mes y día en que se celebra, el día de la semana, el nombre de la festividad y el tipo (oficial o no oficial).
+
+- 400 Bad Request: Si se proporciona un año inválido o no se proporciona ningún año.
+
+### GET /api/v1/holidays/holidays_and_observances
+
+Obtiene una lista de todas las festividades y observancias en Uruguay para un año determinado.
+
+**Parámetros**
+
+- year (obligatorio): El año para el cual se desean obtener las festividades. Debe ser un número entero de cuatro dígitos.
+
+**Respuesta**
+
+- 200 OK: Devuelve un objeto JSON que contiene información sobre cada festividad y observancia, incluyendo el mes y día en que se celebra, el día de la semana, el nombre de la festividad y el tipo (oficial o no oficial).
+
+- 400 Bad Request: Si se proporciona un año inválido o no se proporciona ningún año.
+
+### GET /api/v1/holidays/holidays_and_observances_including_locals
+
+Obtiene una lista de todas las festividades, observancias y festivales locales en Uruguay para un año determinado.
+
+**Parámetros**
+
+- year (obligatorio): El año para el cual se desean obtener las festividades. Debe ser un número entero de cuatro dígitos.
+
+**Respuesta**
+
+- 200 OK: Devuelve un objeto JSON que contiene información sobre cada festividad, observancia y festival local, incl
+
 ---
 
 ### Inspirado por 💡:

--- a/app/controllers/api/v1/holidays_controller.rb
+++ b/app/controllers/api/v1/holidays_controller.rb
@@ -1,0 +1,77 @@
+class Api::V1::HolidaysController < ApplicationController
+  before_action :check_year
+
+  def show
+    holidays_and_observances = scrape_holidays_table("#{url}?hol=4199193")
+
+    render json: holidays_and_observances
+  end
+
+  def official
+    official = scrape_holidays_table("#{url}?hol=1")
+
+    render json: official
+  end
+
+
+  def official_and_non_working
+    official_and_non_working = scrape_holidays_table("#{url}?hol=9")
+
+    render json: official_and_non_working
+  end
+
+  def holidays_and_observances
+    holidays_and_observances = scrape_holidays_table("#{url}?hol=25")
+
+    render json: holidays_and_observances
+  end
+
+  def holidays_and_observances_including_locals
+    holidays_and_observances_including_locals = scrape_holidays_table("#{url}?hol=4194329")
+
+    render json: holidays_and_observances_including_locals
+  end
+
+  private
+
+  def check_year
+    @year = params[:year]
+
+    if !@year.present? || @year.to_i.to_s != @year
+      return render json: { error: 'Invalid year' }, status: 400
+    end
+  end
+
+  def url
+    "https://www.timeanddate.com/holidays/uruguay/#{@year}"
+  end
+
+  def scrape_holidays_table(url)
+    response = HTTParty.get(url)
+    doc = Nokogiri::HTML(response.body)
+
+    holidays_data = []
+
+    holidays_table = doc.css('#holidays-table')
+    table_body = holidays_table.css('tbody')
+
+    table_body.css('tr.showrow').each do |row|
+      day_month = row.css('th').text.strip
+
+      tds = row.css('td')
+      next unless tds[0].present?
+      day_of_week = tds[0].text.strip
+      holiday_name = tds[1].text.strip
+      holiday_type = tds[2].text.strip
+
+      holidays_data <<  {
+        day_month: day_month,
+        day_of_week: day_of_week,
+        holiday_name: holiday_name,
+        holiday_type: holiday_type
+      }
+    end
+
+    holidays_data
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,14 @@ Rails.application.routes.draw do
         get 'index'
         get ':name', to: 'gasoline#show'
       end
+
+      scope 'holidays', controller: 'holidays', as: 'holidays' do
+        get ':year', to: 'holidays#show'
+        get 'official/:year', to: 'holidays#official'
+        get 'official_and_non_working/:year', to: 'holidays#official_and_non_working'
+        get 'holidays_and_observances/:year', to: 'holidays#holidays_and_observances'
+        get 'holidays_and_observances_including_locals/:year', to: 'holidays#holidays_and_observances_including_locals'
+      end
     end
   end
   # Defines the root path route ("/")

--- a/test/controllers/api/v1/holidays_controller_test.rb
+++ b/test/controllers/api/v1/holidays_controller_test.rb
@@ -1,0 +1,43 @@
+require "test_helper"
+
+class Api::V1::HolidaysControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @year = Time.now.year
+  end
+
+  test "should get show" do
+    get api_v1_holidays_path(year: @year)
+    assert_response :success
+    assert JSON.parse(response.body).length > 0
+  end
+
+  test "should get official" do
+    get "/api/v1/holidays/official/#{@year}"
+    assert_response :success
+    assert JSON.parse(response.body).length > 0
+  end
+
+  test "should get official and non-working" do
+    get "/api/v1/holidays/official_and_non_working/#{@year}"
+    assert_response :success
+    assert JSON.parse(response.body).length > 0
+  end
+
+  test "should get holidays and observances" do
+    get "/api/v1/holidays/holidays_and_observances/#{@year}"
+    assert_response :success
+    assert JSON.parse(response.body).length > 0
+  end
+
+  test "should get holidays and observances including locals" do
+    get "/api/v1/holidays/holidays_and_observances_including_locals/#{@year}"
+    assert_response :success
+    assert JSON.parse(response.body).length > 0
+  end
+
+  test "should return error for invalid year" do
+    get "/api/v1/holidays/InvalidYear"
+    assert_response :bad_request
+    assert JSON.parse(response.body)["error"] == "Invalid year"
+  end
+end


### PR DESCRIPTION
# Description
This pull request adds new endpoints to the Holidays API, allowing users to retrieve different types of holiday data for Uruguay. The new endpoints include "official," "official_and_non_working," "holidays_and_observances," and "holidays_and_observances_including_locals."

Each endpoint returns a JSON object containing holiday data for the specified year, as scraped from the Time and Date website. Additionally, the PR includes updates to the API documentation to reflect the new endpoints.






