### PR TITLE
Feat: add billboard controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,34 @@ Obtiene una lista de todas las festividades, observancias y festivales locales e
 
 - 200 OK: Devuelve un objeto JSON que contiene información sobre cada festividad, observancia y festival local, incl
 
+## CARTELERA
+
+## GET /api/v1/billboard/index
+
+Obtiene una lista de eventos en diferentes categorías de "Cartelera".
+
+**Respuesta**
+
+- 200 OK: Devuelve un objeto JSON que contiene una lista de items para cada una de las siguientes categorías: "arte," "cable," "cine," "musica," "teatro," y "videos." Cada categoría contiene un array de objetos JSON, donde cada objeto representa un evento.
+
+- 500 Internal Server Error: Si ocurre algún error en el servidor al obtener la lista de items.
+
+## GET /api/v1/billboard/:event_type
+
+Obtiene una lista de items para una categoría específica.
+
+**Parámetros**
+
+- event_type: El tipo de evento que se desea obtener. Debe ser una de las siguientes opciones: "art," "cable," "movies," "music," "theater," o "videos".
+
+**Respuesta**
+
+- 200 OK: Devuelve un objeto JSON que contiene una lista de items para la categoría especificada. Cada item es un objeto JSON que representa a un evento.
+
+- 404 Not Found: Si el tipo de evento solicitado no existe en la lista de categorías.
+
+- 500 Internal Server Error: Si ocurre algún error en el servidor al obtener la lista de items.
+
 ---
 
 ### Inspirado por 💡:

--- a/app/controllers/api/v1/billboard_controller.rb
+++ b/app/controllers/api/v1/billboard_controller.rb
@@ -1,0 +1,248 @@
+class Api::V1::BillboardController < ApplicationController
+
+  BASE_URL = 'https://www.cartelera.com.uy'
+
+  def index
+    render json: billboard_data
+  end
+
+  def show
+    event_type = params[:event_type]
+
+    return render json: { error: 'Invalid event type' }, status: :not_found unless valid_event_types.include?(event_type)
+    return render json: scrape_data(event_type)
+  end
+
+  def scrape_data(type)
+    url = build_url(type)
+    response = HTTParty.get(url)
+    doc = Nokogiri::HTML(response.body)
+    articles = doc.css('ul.listado-eventos li article')
+    data = []
+
+    articles.each do |article|
+      data << extract_data(article, type)
+    end
+
+    data
+  end
+
+  private
+
+  def extract_data(article, type)
+    img = article.css('.poster-container > a > img').first&.[]('src')
+    name = article.css('.info-holder .name').text.strip
+    event_data = article.css('.info-holder .event-data li')
+
+    case type
+      when 'art'
+        return {
+          "#{name}": {
+            genre: event_data.css('strong')[0]&.text&.strip,
+            show: event_data.css('strong')[1]&.text&.strip,
+            room: event_data.css('strong')[2]&.text&.strip,
+            img: img,
+          }
+        }
+
+      when 'cable'
+        return {
+          "#{name}": {
+            channel: event_data.css('strong')[0]&.text&.strip,
+            shcedule: event_data.css('strong')[1]&.text&.strip,
+            genre: event_data.css('strong')[2]&.text&.strip,
+            director: event_data.css('strong')[3]&.text&.strip,
+            protagonists: event_data.css('strong')[4]&.text&.strip,
+            img: img,
+          }
+        }
+
+      when 'theater'
+      theater_data = {
+        "#{name}": {
+          genre: event_data.css('strong')[0]&.text&.strip,
+          director: event_data.css('strong')[1]&.text&.strip,
+          room: event_data.css('strong')[2]&.text&.strip,
+          img: img,
+          today_schedules: extract_schedules(article)
+        }
+      }
+      return theater_data
+
+    when 'videos'
+      director = event_data.css('strong')[1]&.text&.strip
+      protagonists = event_data.css('strong')[2]&.text&.strip
+      available_on = event_data.css('a').first&.[]('href')
+
+      return {
+        "#{name}": {
+          genre: event_data.css('strong')[0]&.text&.strip,
+          director: event_data.css('strong')[1]&.text&.strip,
+          protagonists: event_data.css('strong')[2]&.text&.strip,
+          available_on: event_data.css('a').first&.[]('href'),
+          img: data[:img]
+        }
+      }
+
+    when 'music'
+      return {
+        "#{name}": {
+          cast: event_data.css('strong')[0]&.text&.strip,
+          room: data[:event_data][1]&.text&.strip,
+          locations: data[:event_data][2]&.text&.strip,
+          img: img,
+        }
+      }
+
+    when 'movies'
+      return {
+        "#{name}": {
+          genre: event_data.css('strong')[0]&.text&.strip,
+          director: event_data.css('strong')[1]&.text&.strip,
+          protagonists: event_data.css('strong')[2]&.text&.strip,
+          img: img,
+          today_schedules: extract_schedules(article)
+        }
+      }
+      end
+  end
+
+  def extract_schedules(article)
+    schedules_list = article.css('.horarios-container .salas > li')
+    return [] if schedules_list.empty?
+
+    schedules = []
+    schedules_list.each do |schedule_item|
+      place = schedule_item.css('.heading.small').text.strip
+      shcedule_data = {
+        "#{place}": {
+          hours: [],
+          language: [],
+        }
+      }
+
+      schedule_item.css('ul.lista-horarios > li').each do |schedule|
+        shcedule_data[:"#{place}"][:language] << schedule.css('.subheading').text.strip
+        shcedule_data[:"#{place}"][:hours] << schedule.css('ul > li.hour').text.strip
+      end
+
+      schedules << shcedule_data
+    end
+
+    return schedules
+  end
+
+
+  def valid_event_types
+    %w[movies music videos theater cable art]
+  end
+
+  def build_url(type)
+    case type
+      when 'art'
+        "#{BASE_URL}/avercarteleraarte.aspx?123"
+      when 'cable'
+        "#{BASE_URL}/apeliculafuncionescable.aspx?,FILM,0,0,109"
+      when 'theater'
+        "#{BASE_URL}/apeliculafunciones.aspx?,,PELICULAS,OBRA,0,111"
+      when 'videos'
+        "#{BASE_URL}/avercarteleraondemand.aspx?121"
+      when 'music'
+        "#{BASE_URL}/aporfechas.aspx?6,112,0,2"
+      when 'movies'
+        "#{BASE_URL}/apeliculafunciones.aspx?,,PELICULAS,FILM,0,108"
+      end
+  end
+
+  def billboard_data
+    sections_data = sections.map do |section|
+      { "#{section['id']}": events_data(section) }
+    end
+
+    sections_data.inject(&:merge)
+  end
+
+  def sections
+    doc = Nokogiri::HTML(cartelera_response.body)
+    doc.css('section')
+  end
+
+  def cartelera_response
+    HTTParty.get("https://www.cartelera.com.uy/")
+  end
+
+  def events_data(section)
+    section.css('.slider-holder .listado-eventos li article').map do |event|
+      send("#{section['id']}_event_data", event)
+    end
+  end
+
+  def cine_event_data(event)
+    {
+      "#{event.css('.container .name').text.strip}": {
+        type: event.css('.container .type').text.strip,
+        trailer: event.css('.container a.trailer').first&.[]('href'),
+        info: event.css('a').first&.[]('href'),
+        img: event.css('a img').first&.[]('src')
+      }
+    }
+  end
+
+  def musica_event_data(event)
+    {
+      "#{event.css('.container .name').text.strip}": {
+        featured: event.css('.container .destacado').text.strip,
+        venue: event.css('.container .venue').text.strip,
+        info: event.css('a').first&.[]('href'),
+        img: event.css('a img').first&.[]('src')
+      }
+    }
+  end
+
+  def videos_event_data(event)
+    {
+      "#{event.css('.container .name').text.strip}": {
+        featured: event.css('.container .destacado').text.strip,
+        genre: event.css('.container p').last.text.strip,
+        info: event.css('a').first&.[]('href'),
+        img: event.css('a img').first&.[]('src')
+      }
+    }
+  end
+
+  def teatro_event_data(event)
+    {
+      "#{event.css('.container .name').text.strip}": {
+        featured: event.css('.container .destacado').text.strip,
+        venue: event.css('.container .venue').text.strip,
+        info: event.css('a').first&.[]('href'),
+        img: event.css('a img').first&.[]('src')
+      }
+    }
+  end
+
+  def cable_event_data(event)
+    {
+      "#{event.css('.container .name').text.strip}": {
+        featured: event.css('.container .destacado').text.strip,
+        channel: event.css('.container .highlight').last.text.strip,
+        genre: event.css('.container p').first.text.strip,
+        info: event.css('a').first&.[]('href'),
+        img: event.css('a img').first&.[]('src')
+      }
+    }
+  end
+
+  def arte_event_data(event)
+    {
+      "#{event.css('.container .name').text.strip}": {
+        featured: event.css('.container .destacado').text.strip,
+        genre: event.css('.container p').first.text.strip,
+        artist: event.css('.container p')[1]&.text&.strip,
+        venue: event.css('.container p').last.text.strip,
+        info: event.css('a').first&.[]('href'),
+        img: event.css('a img').first&.[]('src')
+      }
+    }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,11 @@ Rails.application.routes.draw do
         get 'holidays_and_observances/:year', to: 'holidays#holidays_and_observances'
         get 'holidays_and_observances_including_locals/:year', to: 'holidays#holidays_and_observances_including_locals'
       end
+      
+      scope 'billboard', controller: 'billboard', as: 'billboard' do
+        get 'index'
+        get ':event_type', to: 'billboard#show'
+      end
     end
   end
   # Defines the root path route ("/")

--- a/test/controllers/api/v1/billboard_controller_test.rb
+++ b/test/controllers/api/v1/billboard_controller_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+
+class Api::V1::BillboardControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get api_v1_billboard_index_url
+    assert_response :success
+
+    response_data = JSON.parse(response.body)
+    assert_equal response_data.keys.sort, ["arte", "cable", "cine", "musica", "teatro", "videos"].sort
+
+    response_data.each do |key, value|
+      assert_instance_of Array, value
+      value.each do |item|
+        assert_instance_of Hash, item
+      end
+    end
+  end
+
+  test "should return event type data" do
+    get api_v1_billboard_path(:art)
+    assert_response :success
+    assert JSON.parse(response.body).is_a?(Array)
+
+    get api_v1_billboard_path(:cable)
+    assert_response :success
+    assert JSON.parse(response.body).is_a?(Array)
+
+    get api_v1_billboard_path(:movies)
+    assert_response :success
+    assert JSON.parse(response.body).is_a?(Array)
+
+    get api_v1_billboard_path(:music)
+    assert_response :success
+    assert JSON.parse(response.body).is_a?(Array)
+
+    get api_v1_billboard_path(:theater)
+    assert_response :success
+    assert JSON.parse(response.body).is_a?(Array)
+
+    get api_v1_billboard_path(:videos)
+    assert_response :success
+    assert JSON.parse(response.body).is_a?(Array)
+  end
+
+  test "should return error for invalid event type" do
+    get api_v1_billboard_path(:invalid_event_type)
+    assert_response :not_found
+  end
+end


### PR DESCRIPTION
# Description
This PR adds the Billboard controller. The billboard would show different types of events for a series of categories: music, movies, art, cable, videos, theater. Each "event" will have a series of attributes that depends on the category.