### PR TITLE
Feat: add Montevideo IMM events endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,53 @@ Obtiene el listado completo de un tipo de cartelera.
 - 404 Not Found: Si el tipo no existe.
 - 500 Internal Server Error: Si ocurre algún error al obtener los datos.
 
+---
+
+### GET /api/v1/events/montevideo
+
+Obtiene todos los eventos culturales del portal de la Intendencia de Montevideo (eventos.montevideo.gub.uy), agrupados por categoría. Recorre todas las páginas de cada categoría.
+
+**Parámetros**
+
+Este endpoint no requiere parámetros.
+
+**Respuesta**
+
+- 200 OK: Objeto con una clave por categoría (`artes-escenicas`, `gastronomia`, `institucional`, `audiovisual`, `literatura`, `paseos`, `recreacion`, `musica`, `deportes`, `carnaval`, `artes-visuales`), cada una con un array de eventos.
+- 500 Internal Server Error: Si ocurre algún error al obtener los datos.
+
+---
+
+### GET /api/v1/events/montevideo/:category
+
+Obtiene los eventos de una categoría puntual del portal de la Intendencia de Montevideo. Recorre todas las páginas de la categoría.
+
+**Parámetros**
+
+- `category`: `artes-escenicas`, `gastronomia`, `institucional`, `audiovisual`, `literatura`, `paseos`, `recreacion`, `musica`, `deportes`, `carnaval`, `artes-visuales`.
+
+**Respuesta**
+
+- 200 OK: Array de eventos. Cada evento incluye: `source`, `source_url`, `title`, `venue`, `date`, `start_date`, `end_date`, `category`, `thumbnail`, `event_link`.
+
+```json
+{
+  "source": "Eventos Montevideo",
+  "source_url": "https://eventos.montevideo.gub.uy",
+  "title": "Cultura ciclista y mini rodada musical",
+  "venue": "Rodala (Sarandí 263)",
+  "date": "Sábado 20 de junio de 11:00 a 18:00 h",
+  "start_date": "2026-06-20T14:00:00Z",
+  "end_date": "2026-06-20T21:00:00Z",
+  "category": "Deportes",
+  "thumbnail": "https://eventos.montevideo.gub.uy/sites/eventos.montevideo.gub.uy/files/styles/listado_categorias/public/2026-06/pexels-lisa-stroud-bici.jpg",
+  "event_link": "https://eventos.montevideo.gub.uy/evento/sabados-en-ciudad-vieja/cultura-ciclista-y-mini-rodada-musical"
+}
+```
+
+- 404 Not Found: Si la categoría no existe.
+- 500 Internal Server Error: Si ocurre algún error al obtener los datos.
+
 </details>
 
 <details>

--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -55,4 +55,16 @@ class Api::V1::EventsController < ApplicationController
 
     render json: CarteleraService.fetch_by_type(event_type)
   end
+
+  def montevideo
+    category = params[:category]
+
+    return render json: { error: 'Invalid category' }, status: :not_found unless MontevideoEventsService.valid_category?(category)
+
+    render json: MontevideoEventsService.fetch_by_category(category)
+  end
+
+  def montevideo_all
+    render json: MontevideoEventsService.fetch_all
+  end
 end

--- a/app/services/montevideo_events_service.rb
+++ b/app/services/montevideo_events_service.rb
@@ -21,25 +21,16 @@ class MontevideoEventsService
     def fetch_by_category(category)
       return nil unless valid_category?(category)
 
-      events = []
-      page = 0
-      loop do
-        url = "#{BASE_URL}/categoria/#{category}?page=#{page}"
-        doc = Nokogiri::HTML(HTTParty.get(url).body)
-        articles = doc.css('article.node--type-actividad')
-        break if articles.empty?
+      first_doc = fetch_doc(category, 0)
+      events = parse_articles(first_doc)
+      last = last_page(first_doc)
+      return events if last.zero?
 
-        events += articles.map { |article| extract_data(article) }
-        page += 1
-      end
-
-      events
+      events + (1..last).map { |page| Thread.new(page) { |p| parse_articles(fetch_doc(category, p)) } }.flat_map(&:value)
     end
 
     def fetch_all
-      VALID_CATEGORIES.each_with_object({}) do |category, result|
-        result[category.to_sym] = fetch_by_category(category)
-      end
+      VALID_CATEGORIES.map { |category| Thread.new(category) { |c| [c.to_sym, fetch_by_category(c)] } }.map(&:value).to_h
     end
 
     def valid_category?(category)
@@ -47,6 +38,19 @@ class MontevideoEventsService
     end
 
     private
+
+    def fetch_doc(category, page)
+      Nokogiri::HTML(HTTParty.get("#{BASE_URL}/categoria/#{category}?page=#{page}").body)
+    end
+
+    def parse_articles(doc)
+      doc.css('article.node--type-actividad').map { |article| extract_data(article) }
+    end
+
+    def last_page(doc)
+      href = doc.css('a[title="Ir a la última página"]').first&.[]('href')
+      href && href.match(/page=(\d+)/) ? Regexp.last_match(1).to_i : 0
+    end
 
     def extract_data(article)
       title_link = article.css('.field--name-title a').first

--- a/app/services/montevideo_events_service.rb
+++ b/app/services/montevideo_events_service.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+# Servicio de eventos de la Intendencia de Montevideo.
+#
+# Scrapea el portal de eventos culturales de Montevideo, que organiza las
+# actividades por categoría (música, deportes, gastronomía, etc.).
+#
+# Categorías válidas: artes-escenicas, gastronomia, institucional, audiovisual,
+# literatura, paseos, recreacion, musica, deportes, carnaval, artes-visuales
+#
+# Fuente: https://eventos.montevideo.gub.uy
+class MontevideoEventsService
+  BASE_URL = 'https://eventos.montevideo.gub.uy'
+
+  VALID_CATEGORIES = %w[
+    artes-escenicas gastronomia institucional audiovisual literatura
+    paseos recreacion musica deportes carnaval artes-visuales
+  ].freeze
+
+  class << self
+    def fetch_by_category(category)
+      return nil unless valid_category?(category)
+
+      events = []
+      page = 0
+      loop do
+        url = "#{BASE_URL}/categoria/#{category}?page=#{page}"
+        doc = Nokogiri::HTML(HTTParty.get(url).body)
+        articles = doc.css('article.node--type-actividad')
+        break if articles.empty?
+
+        events += articles.map { |article| extract_data(article) }
+        page += 1
+      end
+
+      events
+    end
+
+    def fetch_all
+      VALID_CATEGORIES.each_with_object({}) do |category, result|
+        result[category.to_sym] = fetch_by_category(category)
+      end
+    end
+
+    def valid_category?(category)
+      VALID_CATEGORIES.include?(category)
+    end
+
+    private
+
+    def extract_data(article)
+      title_link = article.css('.field--name-title a').first
+      dates = article.css('.field--name-field-fechas time')
+
+      {
+        source: 'Eventos Montevideo',
+        source_url: BASE_URL,
+        title: title_link&.text&.strip,
+        venue: clean_text(article.css('.field--name-field-donde')),
+        date: clean_text(article.css('.field--name-field-resumen')),
+        start_date: dates[0]&.[]('datetime'),
+        end_date: dates[1]&.[]('datetime'),
+        category: article.css('.field--name-field-categoria-listado a').text.strip.presence,
+        thumbnail: absolute_url(article.css('.field--name-field-imagen-miniatura-listados img').first&.[]('src')),
+        event_link: absolute_url(title_link&.[]('href').to_s),
+      }
+    end
+
+    def clean_text(node)
+      node.text.gsub(/\s+/, ' ').strip.presence
+    end
+
+    def absolute_url(path)
+      return nil if path.nil? || path.empty?
+
+      path.start_with?('http') ? path : "#{BASE_URL}#{path}"
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,8 @@ Rails.application.routes.draw do
         get 'redtickets'
         get 'teatro_solis'
         get 'sodre'
+        get 'montevideo', to: 'events#montevideo_all'
+        get 'montevideo/:category', to: 'events#montevideo'
       end
 
       scope 'horoscope', controller: 'horoscope', as: 'horoscope' do


### PR DESCRIPTION
## Qué hace

Agrega los eventos culturales del portal de la Intendencia de Montevideo (eventos.montevideo.gub.uy) a la API de eventos.

## Endpoints nuevos

| Endpoint | Descripción |
|---|---|
| `GET /api/v1/events/montevideo` | Todos los eventos, agrupados por categoría (las 11) |
| `GET /api/v1/events/montevideo/:category` | Eventos de una categoría puntual |

Categorías: `artes-escenicas`, `gastronomia`, `institucional`, `audiovisual`, `literatura`, `paseos`, `recreacion`, `musica`, `deportes`, `carnaval`, `artes-visuales`.

## Detalles

- `MontevideoEventsService` scrapea el portal (HTTParty + Nokogiri), mismo patrón que los demás services de eventos.
- Cada evento devuelve: `source`, `source_url`, `title`, `venue`, `date`, `start_date`, `end_date`, `category`, `thumbnail`, `event_link`.
- **Paginación completa**: usa el link "última página" del paginador para traer todas las páginas.
- **Fetching en paralelo** (Ruby Threads) en dos niveles — páginas dentro de una categoría y las categorías entre sí. `/montevideo` completo (~150 eventos, ~41 requests) baja a ~1s.
- Categoría inválida → 404.
- README actualizado con la documentación de ambos endpoints.
