### PR TITLE
Feat: expandir headlines con categorías Deportes, Pantallazo y Tecnología

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,35 @@ Obtiene una lista de todas las festividades y días feriados en Uruguay para el 
 
 ### GET /api/v1/news/headlines
 
-Obtiene una lista de los titulares de noticias más recientes en Uruguay.
+Obtiene los titulares más leídos de Montevideo Portal, agrupados por sección.
+
+**Respuesta**
+
+- 200 OK: Array con una entrada por sección. Cada entrada incluye `source` y `headlines`.
+
+```json
+[
+  {
+    "source": "Noticias",
+    "headlines": [
+      {
+        "href": "https://www.montevideo.com.uy/...",
+        "title": "Título de la noticia",
+        "img": "https://imagenes.montevideo.com.uy/..."
+      }
+    ]
+  }
+]
+```
+
+**Fuentes incluidas**
+
+| Source | Descripción |
+|--------|-------------|
+| `Noticias` | Más leídas generales del portal |
+| `Deportes` | Más leídas de la sección Deportes |
+| `Pantallazo` | Más leídas de la sección Pantallazo (espectáculos) |
+| `Tecnología` | Últimas noticias de Ciencia y Tecnología |
 
 </details>
 

--- a/app/controllers/api/v1/news_controller.rb
+++ b/app/controllers/api/v1/news_controller.rb
@@ -1,34 +1,35 @@
 class Api::V1::NewsController < ApplicationController
-  def headlines
-    source = 'Montevideo Portal'
-    url = "https://www.montevideo.com.uy/anranking.aspx?0,1798,1,0,D"
+  SOURCES = [
+    { name: 'Noticias', url: 'https://www.montevideo.com.uy/anranking.aspx?0,1798,1,0,D' },
+    { name: 'Deportes', url: 'https://www.montevideo.com.uy/anranking.aspx?0,1975,1,94,H' },
+    { name: 'Pantallazo', url: 'https://www.montevideo.com.uy/anranking.aspx?0,1821,1,756,H' },
+    { name: 'Tecnología', url: 'https://www.montevideo.com.uy/acategoria.aspx?412' }
+  ].freeze
 
-    response = HTTParty.get(url)
+  def headlines
+    data = SOURCES.map { |source| scrape_source(source) }
+    render json: data
+  end
+
+  private
+
+  def scrape_source(source)
+    response = HTTParty.get(source[:url])
     doc = Nokogiri::HTML(response.body)
 
-    titles = doc.css('h2.title')
-
-    data = [
-      {
-        source: source,
-        headlines: []
-      }
-    ]
-
-    titles.each do |title|
-      data.first[:headlines] << {
-        href: title.css('a').first['href'],
-        title: title.text
-      }
+    headlines = doc.css('h2.title').map do |title|
+      anchor = title.css('a').first
+      { href: anchor['href'], title: title.text.strip }
     end
 
-    data.first[:headlines].each do |headline|
-      response = HTTParty.get(headline[:href])
-      doc = Nokogiri::HTML(response.body)
-      img_src = doc.css('.foto-ppal.hidden-xs img').first&.[]('src') || doc.css('#gallery-1 img').first&.[]('src') || ""
-      headline[:img] = img_src
+    headlines.each do |headline|
+      article_response = HTTParty.get(headline[:href])
+      article_doc = Nokogiri::HTML(article_response.body)
+      headline[:img] = article_doc.css('.foto-ppal.hidden-xs img').first&.[]('src') ||
+                       article_doc.css('#gallery-1 img').first&.[]('src') ||
+                       ''
     end
 
-    render json: data
+    { source: source[:name], headlines: headlines }
   end
 end

--- a/test/controllers/api/v1/news_controller_test.rb
+++ b/test/controllers/api/v1/news_controller_test.rb
@@ -1,0 +1,104 @@
+require "test_helper"
+require "webmock/minitest"
+
+class Api::V1::NewsControllerTest < ActionDispatch::IntegrationTest
+  ARTICLE_URL_1 = "https://www.montevideo.com.uy/Test/Articulo-uno-uc001"
+  ARTICLE_URL_2 = "https://www.montevideo.com.uy/Test/Articulo-dos-uc002"
+
+  RANKING_HTML = <<~HTML
+    <html><body>
+      <h2 class="title"><a href="#{ARTICLE_URL_1}">Título de prueba 1</a></h2>
+      <h2 class="title"><a href="#{ARTICLE_URL_2}">Título de prueba 2</a></h2>
+    </body></html>
+  HTML
+
+  ARTICLE_HTML_WITH_IMG = <<~HTML
+    <html><body>
+      <div class="foto-ppal hidden-xs"><img src="https://imagenes.montevideo.com.uy/foto.jpg"></div>
+    </body></html>
+  HTML
+
+  ARTICLE_HTML_WITH_GALLERY = <<~HTML
+    <html><body>
+      <div id="gallery-1"><img src="https://imagenes.montevideo.com.uy/gallery.jpg"></div>
+    </body></html>
+  HTML
+
+  ARTICLE_HTML_NO_IMG = "<html><body><p>Sin imagen</p></body></html>"
+
+  setup do
+    Api::V1::NewsController::SOURCES.each do |source|
+      stub_request(:get, source[:url]).to_return(body: RANKING_HTML, status: 200)
+    end
+
+    stub_request(:get, ARTICLE_URL_1).to_return(body: ARTICLE_HTML_WITH_IMG, status: 200)
+    stub_request(:get, ARTICLE_URL_2).to_return(body: ARTICLE_HTML_WITH_IMG, status: 200)
+  end
+
+  test "returns 200" do
+    get api_v1_news_headlines_path
+    assert_response :success
+  end
+
+  test "returns all four sources" do
+    get api_v1_news_headlines_path
+    json = JSON.parse(response.body)
+    assert_equal %w[Noticias Deportes Pantallazo Tecnología], json.map { |s| s["source"] }
+  end
+
+  test "each source contains headlines" do
+    get api_v1_news_headlines_path
+    json = JSON.parse(response.body)
+    json.each do |source|
+      assert source["headlines"].is_a?(Array), "#{source["source"]} should have a headlines array"
+      assert source["headlines"].length > 0, "#{source["source"]} should have at least one headline"
+    end
+  end
+
+  test "headlines have title, href and img" do
+    get api_v1_news_headlines_path
+    json = JSON.parse(response.body)
+    json.each do |source|
+      headline = source["headlines"].first
+      assert headline.key?("title"), "headline missing title"
+      assert headline.key?("href"),  "headline missing href"
+      assert headline.key?("img"),   "headline missing img"
+    end
+  end
+
+  test "headline title is stripped" do
+    get api_v1_news_headlines_path
+    json = JSON.parse(response.body)
+    assert_equal "Título de prueba 1", json.first["headlines"].first["title"]
+  end
+
+  test "headline href is preserved" do
+    get api_v1_news_headlines_path
+    json = JSON.parse(response.body)
+    assert_equal ARTICLE_URL_1, json.first["headlines"].first["href"]
+  end
+
+  test "headline img is fetched from foto-ppal" do
+    get api_v1_news_headlines_path
+    json = JSON.parse(response.body)
+    assert_equal "https://imagenes.montevideo.com.uy/foto.jpg", json.first["headlines"].first["img"]
+  end
+
+  test "headline img falls back to gallery-1" do
+    stub_request(:get, ARTICLE_URL_1).to_return(body: ARTICLE_HTML_WITH_GALLERY, status: 200)
+    stub_request(:get, ARTICLE_URL_2).to_return(body: ARTICLE_HTML_WITH_GALLERY, status: 200)
+
+    get api_v1_news_headlines_path
+    json = JSON.parse(response.body)
+    assert_equal "https://imagenes.montevideo.com.uy/gallery.jpg", json.first["headlines"].first["img"]
+  end
+
+  test "headline img is empty string when no image found" do
+    stub_request(:get, ARTICLE_URL_1).to_return(body: ARTICLE_HTML_NO_IMG, status: 200)
+    stub_request(:get, ARTICLE_URL_2).to_return(body: ARTICLE_HTML_NO_IMG, status: 200)
+
+    get api_v1_news_headlines_path
+    json = JSON.parse(response.body)
+    assert_equal "", json.first["headlines"].first["img"]
+  end
+end


### PR DESCRIPTION
## Summary

- Agrega 3 nuevas fuentes al endpoint `GET /api/v1/news/headlines`: **Deportes**, **Pantallazo** y **Tecnología**
- Refactoriza `NewsController` extrayendo la lógica de scraping a `scrape_source` (método privado), iterando sobre el array `SOURCES`
- Usa los URLs de anranking específicos por categoría descubiertos vía inspección del HTML del portal (`data-content-url`)
- Tecnología usa `acategoria.aspx?412` ya que no tiene ranking propio por categoría

## Test plan

- [x] 9 tests con WebMock cubriendo: status 200, las 4 fuentes presentes, estructura de headlines (title/href/img), fallback de imagen a `gallery-1`, imagen vacía cuando no hay imagen
- [x] `bin/rails test test/controllers/api/v1/news_controller_test.rb` → 9 runs, 0 failures
- [x] Endpoint probado en local contra el sitio real, top 3 de cada categoría verificados manualmente

🤖 Generated with [Claude Code](https://claude.com/claude-code)